### PR TITLE
Fix the syntax of the `should_panic` attribute

### DIFF
--- a/src/frontend/parser/tiger_parser/token.rs
+++ b/src/frontend/parser/tiger_parser/token.rs
@@ -84,7 +84,7 @@ mod tests{
 
 
     #[test]
-    #[should_panic("Expecting char. Identifier found")]
+    #[should_panic(expected = "Expecting Character, found identifier")]
     //the transform_ch distinguishes char from other
     fn not_a_character(){
         let src="ascii_code123";


### PR DESCRIPTION
Hi there!

The Rust compiler accidentally accepted certain invalid forms of the `should_panic` attribute.
This is being fixed in this change to the Rust compiler: https://github.com/rust-lang/rust/pull/143808
Because the change will break this project, I'm submitting a fix PR as a courtesy, this should make sure your project continues to build correctly on new versions of Rust
